### PR TITLE
Fix readthedocs

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -5,10 +5,11 @@
 version: 2
 
 sphinx:
+  configuration: doc/source/conf.py
   fail_on_warning: true
 
 build:
-  os: ubuntu-22.04
+  os: ubuntu-24.04
   tools:
     python: "3.11"
 


### PR DESCRIPTION
Add explicit configuration directive, update to ubuntu 24-04 (optional)

See https://about.readthedocs.com/blog/2024/12/deprecate-config-files-without-sphinx-or-mkdocs-config/
