### PR TITLE
Update tests to handle changes in `click`

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -22,7 +22,7 @@ def test_cli_validate_circuit_no_config():
     runner = CliRunner()
     result = runner.invoke(cli, ["validate-circuit"])
     assert result.exit_code == 2
-    assert "Missing argument 'CONFIG_FILE'" in result.stdout
+    assert "Missing argument 'CONFIG_FILE'" in result.output
 
 
 def test_cli_validate_simulation_correct():
@@ -31,11 +31,11 @@ def test_cli_validate_simulation_correct():
         cli, ["validate-simulation", str(TEST_DATA_DIR / "simulation_config.json")]
     )
     assert result.exit_code == 0
-    assert click.style("No Error: Success.", fg="green") in result.stdout
+    assert click.style("No Error: Success.", fg="green") in result.output
 
 
 def test_cli_validate_simulation_no_config():
     runner = CliRunner()
     result = runner.invoke(cli, ["validate-simulation"])
     assert result.exit_code == 2
-    assert "Missing argument 'CONFIG_FILE'" in result.stdout
+    assert "Missing argument 'CONFIG_FILE'" in result.output


### PR DESCRIPTION
* click 8.2.0: https://click.palletsprojects.com/en/stable/changes/#version-8-2-0
   includes these changes: https://github.com/pallets/click/issues/2522 https://github.com/pallets/click/pull/2523

Update the tests so we don't expect errors on stdout, just any output