### PR TITLE
Start using `referencing` for `jsonschema`

### DIFF
--- a/bluepysnap/schemas/definitions/edge.yaml
+++ b/bluepysnap/schemas/definitions/edge.yaml
@@ -1,3 +1,4 @@
+$schema: https://json-schema.org/draft/2020-12/schema
 title: Edge file definitions
 description: schema definitions that apply to all edge files
 $edge_file_defs:

--- a/bluepysnap/schemas/node/biophysical.yaml
+++ b/bluepysnap/schemas/node/biophysical.yaml
@@ -1,3 +1,4 @@
+$schema: https://json-schema.org/draft/2020-12/schema
 title: Nodes - biophysical
 description: schema for biophysical node types
 allOf: [{ $ref: "#/$node_file_defs/nodes_file_root" }]

--- a/bluepysnap/schemas/schemas.py
+++ b/bluepysnap/schemas/schemas.py
@@ -7,6 +7,7 @@ import importlib_resources
 import jsonschema
 import numpy as np
 import yaml
+from referencing import Registry, Resource
 
 from bluepysnap.exceptions import BluepySnapValidationError
 
@@ -236,13 +237,14 @@ def validate_edges_schema(path, edges_type, virtual, ignore_datatype_errors):
     return _wrap_errors(path, errors, "/", ignore_datatype_errors)
 
 
-def _resolve_types(resolver, types):
-    """Use jsonschema `resolver` to resolve the `types` dict."""
+def _resolve_types(registry, types):
+    """Use jsonschema `registry` to resolve the `types` dict."""
     cache = {}
 
     def _resolve_type(type_):
         if type_ not in cache:
-            type_ = resolver.resolve(type_)[1]["properties"]["datatype"]["const"]
+            resolved = registry.resolver().lookup(type_)
+            type_ = resolved.contents["properties"]["datatype"]["const"]
             if hasattr(np, type_):
                 cache[type_] = getattr(np, type_)
             elif type_ == "utf-8":
@@ -253,9 +255,11 @@ def _resolve_types(resolver, types):
     return {k: _resolve_type(v["$ref"]) for k, v in types.items()}
 
 
-def _get_reference_resolver(schema):
-    """Get reference resolver for the given schema."""
-    return jsonschema.validators.RefResolver("", schema)
+def _get_jsonschema_registry(schema):
+    """Get registry for the given schema."""
+    resource = Resource.from_contents(schema)
+    registry = Registry().with_resource("", resource)
+    return registry
 
 
 def nodes_schema_types(nodes_type):
@@ -268,7 +272,7 @@ def nodes_schema_types(nodes_type):
         dict: name -> type of column
     """
     schema = _parse_schema("node", nodes_type)
-    resolver = _get_reference_resolver(schema)
+    registry = _get_jsonschema_registry(schema)
 
     schema = schema["$node_file_defs"]["nodes_file_root"]["properties"]["nodes"]
     schema = schema["patternProperties"][""]["properties"]["0"]["properties"]
@@ -276,7 +280,7 @@ def nodes_schema_types(nodes_type):
     del schema["dynamics_params"]
     del schema["@library"]
 
-    return _resolve_types(resolver, schema), _resolve_types(resolver, dynamics_params)
+    return _resolve_types(registry, schema), _resolve_types(registry, dynamics_params)
 
 
 def edges_schema_types(edges_type, virtual):
@@ -293,11 +297,11 @@ def edges_schema_types(edges_type, virtual):
         edges_type += "_virtual"
 
     schema = _parse_schema("edge", edges_type)
-    resolver = _get_reference_resolver(schema)
+    registry = _get_jsonschema_registry(schema)
 
     schema = schema["$edge_file_defs"]["edges_file_root"]["properties"]["edges"]
     schema = schema["patternProperties"][""]["properties"]["0"]["properties"]
     del schema["@library"]
     del schema["synapse_id"]
 
-    return _resolve_types(resolver, schema)
+    return _resolve_types(registry, schema)

--- a/bluepysnap/simulation_validation.py
+++ b/bluepysnap/simulation_validation.py
@@ -284,7 +284,7 @@ def _validate_spike_file_contents(input_, config, prefix):
     try:
         spike_ids = _get_ids_from_spike_file(_resolve_path(input_["spike_file"], config))
     except IOError as e:
-        return [BluepySnapValidationError.fatal(f"{prefix}: {' '.join(map(str,e.args))}")]
+        return [BluepySnapValidationError.fatal(f"{prefix}: {' '.join(map(str, e.args))}")]
 
     if nodeset := input_.get("source"):
         sim_ids = _get_ids_from_node_set(nodeset, config)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ dependencies = [
     "cached_property>=1.0",
     "h5py>=3.0.1,<4.0.0",
     "importlib_resources>=5.0.0",
-    "jsonschema>=4.0.0,<5.0.0",
+    "jsonschema>=4.18.0,<5.0.0",
     "libsonata>=0.1.24,<1.0.0",
     "morphio>=3.3.5,<4.0.0",
     "morph-tool>=2.4.3,<3.0.0",
@@ -22,6 +22,7 @@ dependencies = [
     "pandas>=1.0.0",
     "click>=7.0",
     "more-itertools>=8.2.0",
+    "referencing",
 ]
 requires-python = ">=3.9"
 readme = "README.rst"

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -467,13 +467,6 @@ def test_wrong_datatype(field):
         assert f"incorrect datatype 'int16' for '{field}'" in errors[0].message
 
 
-def test__get_reference_resolver():
-    expected = {"const": "test_value"}
-    schema = {"$mock_reference": expected}
-    resolver = test_module._get_reference_resolver(schema)
-    assert resolver.resolve("#/$mock_reference")[1] == expected
-
-
 def test_nodes_schema_types():
     property_types, _ = test_module.nodes_schema_types("biophysical")
     assert "x" in property_types

--- a/tox.ini
+++ b/tox.ini
@@ -20,7 +20,7 @@ extras =
 usedevelop = true
 setenv =
     MPLBACKEND = Agg
-commands = pytest tests --cov={[base]name} --cov-report term-missing --cov-fail-under=100 --cov-report=xml {posargs}
+commands = pytest --cov={[base]name} --cov-report term-missing --cov-fail-under=100 --cov-report=xml {posargs:tests}
 
 [testenv:lint]
 deps =


### PR DESCRIPTION
* the jsonschema package is deprecating `RefResolver`: DeprecationWarning: jsonschema.RefResolver is deprecated as of v4.18.0, in favor of the https://github.com/python-jsonschema/referencing library
* switch to using this library