### PR TITLE
update `validate` schemas to allow for choice of integer width

### DIFF
--- a/.github/workflows/publish-sdist.yml
+++ b/.github/workflows/publish-sdist.yml
@@ -16,7 +16,7 @@ jobs:
     name: Build sdist
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Build SDist
         run: pipx run build --sdist
@@ -24,7 +24,7 @@ jobs:
       - name: Check metadata
         run: pipx run twine check dist/*
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: build
           path: dist
@@ -39,7 +39,7 @@ jobs:
     if: github.event_name == 'release' && github.event.action == 'published'
 
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           name: build
           path: dist

--- a/.github/workflows/run-tox.yml
+++ b/.github/workflows/run-tox.yml
@@ -15,9 +15,9 @@ jobs:
         python-version: ["3.10", "3.11", "3.12", "3.13"]
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies

--- a/bluepysnap/schemas/definitions/datatypes.yaml
+++ b/bluepysnap/schemas/definitions/datatypes.yaml
@@ -1,3 +1,4 @@
+$schema: https://json-schema.org/draft/2020-12/schema
 title: Data Types
 description: data type definitions for schema validation
 $typedefs:
@@ -14,6 +15,7 @@ $typedefs:
     properties:
       datatype:
         const: float32
+
   int8:
     $ref: "#/$typedefs/general"
     properties:
@@ -34,6 +36,12 @@ $typedefs:
     properties:
       datatype:
         const: int64
+  signed_integer:
+    $ref: "#/$typedefs/general"
+    properties:
+      datatype:
+        enum: [int8, int16, int32, int64]
+
   uint8:
     $ref: "#/$typedefs/general"
     properties:
@@ -54,6 +62,12 @@ $typedefs:
     properties:
       datatype:
         const: uint64
+  unsigned_integer:
+    $ref: "#/$typedefs/general"
+    properties:
+      datatype:
+        enum: [uint8, uint16, uint32, uint64]
+
   utf8:
     $ref: "#/$typedefs/general"
     properties:

--- a/bluepysnap/schemas/definitions/edge.yaml
+++ b/bluepysnap/schemas/definitions/edge.yaml
@@ -6,12 +6,12 @@ $edge_file_defs:
     type: object
     properties:
       node_id_to_ranges:
-        $ref: "#/$typedefs/uint64"
+        $ref: "#/$typedefs/unsigned_integer"
       range_to_edge_id:
-        $ref: "#/$typedefs/uint64"
+        $ref: "#/$typedefs/unsigned_integer"
 
   edge_node_ids:
-    $ref: "#/$typedefs/uint64"
+    $ref: "#/$typedefs/unsigned_integer"
     required:
       - attributes
     properties:
@@ -54,7 +54,7 @@ $edge_file_defs:
                 $ref: "#/$edge_file_defs/edge_node_ids"
 
               edge_type_id:
-                $ref: "#/$typedefs/int64"
+                $ref: "#/$typedefs/signed_integer"
 
               "0":
                 type: object
@@ -74,18 +74,18 @@ $edge_file_defs:
                     $ref: "#/$typedefs/float32"
 
                   afferent_section_id:
-                    $ref: "#/$typedefs/uint32"
+                    $ref: "#/$typedefs/unsigned_integer"
                   afferent_section_type:
-                    $ref: "#/$typedefs/uint32"
+                    $ref: "#/$typedefs/unsigned_integer"
                   afferent_section_pos:
                     $ref: "#/$typedefs/float32"
                   afferent_section_offset:
                     $ref: "#/$typedefs/float32"
 
                   afferent_segment_id:
-                    $ref: "#/$typedefs/uint32"
+                    $ref: "#/$typedefs/unsigned_integer"
                   afferent_segment_type:
-                    $ref: "#/$typedefs/uint32"
+                    $ref: "#/$typedefs/unsigned_integer"
                   afferent_segment_pos:
                     $ref: "#/$typedefs/float32"
                   afferent_segment_offset:
@@ -106,18 +106,18 @@ $edge_file_defs:
                     $ref: "#/$typedefs/float32"
 
                   efferent_section_id:
-                    $ref: "#/$typedefs/uint32"
+                    $ref: "#/$typedefs/unsigned_integer"
                   efferent_section_type:
-                    $ref: "#/$typedefs/uint32"
+                    $ref: "#/$typedefs/unsigned_integer"
                   efferent_section_pos:
                     $ref: "#/$typedefs/float32"
                   efferent_section_offset:
                     $ref: "#/$typedefs/float32"
 
                   efferent_segment_id:
-                    $ref: "#/$typedefs/uint32"
+                    $ref: "#/$typedefs/unsigned_integer"
                   efferent_segment_type:
-                    $ref: "#/$typedefs/uint32"
+                    $ref: "#/$typedefs/unsigned_integer"
                   efferent_segment_pos:
                     $ref: "#/$typedefs/float32"
                   efferent_segment_offset:
@@ -134,7 +134,7 @@ $edge_file_defs:
                   u_syn:
                     $ref: "#/$typedefs/float32"
                   n_rrp_vesicles:
-                    $ref: "#/$typedefs/uint32"
+                    $ref: "#/$typedefs/unsigned_integer"
                   spine_length:
                     $ref: "#/$typedefs/float32"
                   spine_morphology:
@@ -148,24 +148,24 @@ $edge_file_defs:
                   u_hill_coefficient:
                     $ref: "#/$typedefs/float32"
                   syn_type_id:
-                    $ref: "#/$typedefs/uint32"
+                    $ref: "#/$typedefs/unsigned_integer"
                   delay:
                     $ref: "#/$typedefs/float32"
 
                   # Connection type is electrical_synapse
                   afferent_junction_id:
-                    $ref: "#/$typedefs/uint32"
+                    $ref: "#/$typedefs/unsigned_integer"
                   afferent_junction_type:
-                    $ref: "#/$typedefs/uint32"
+                    $ref: "#/$typedefs/unsigned_integer"
                   efferent_junction_id:
-                    $ref: "#/$typedefs/uint32"
+                    $ref: "#/$typedefs/unsigned_integer"
                   efferent_junction_type:
-                    $ref: "#/$typedefs/uint32"
+                    $ref: "#/$typedefs/unsigned_integer"
                   # Connection type is synapse_astrocyte
                   astrocyte_section_id:
-                    $ref: "#/$typedefs/uint32"
+                    $ref: "#/$typedefs/unsigned_integer"
                   astrocyte_segment_id:
-                    $ref: "#/$typedefs/uint32"
+                    $ref: "#/$typedefs/unsigned_integer"
                   astrocyte_section_pos:
                     $ref: "#/$typedefs/float32"
                   astrocyte_segment_offset:
@@ -185,7 +185,7 @@ $edge_file_defs:
 
                   # Connection type is endfoot.
                   endfoot_id:
-                    $ref: "#/$typedefs/uint64"
+                    $ref: "#/$typedefs/unsigned_integer"
                   endfoot_surface_x:
                     $ref: "#/$typedefs/float32"
                   endfoot_surface_y:
@@ -199,9 +199,9 @@ $edge_file_defs:
                   endfoot_compartment_perimeter:
                     $ref: "#/$typedefs/float32"
                   vasculature_section_id:
-                    $ref: "#/$typedefs/uint32"
+                    $ref: "#/$typedefs/unsigned_integer"
                   vasculature_segment_id:
-                    $ref: "#/$typedefs/uint32"
+                    $ref: "#/$typedefs/unsigned_integer"
 
                   # Exp2Syn_synapse
                   tau1:
@@ -212,7 +212,7 @@ $edge_file_defs:
                     $ref: "#/$typedefs/float32"
 
                   synapse_id:
-                    $ref: "#/$typedefs/uint64"
+                    $ref: "#/$typedefs/unsigned_integer"
                     required:
                       - attributes
                     properties:

--- a/bluepysnap/schemas/definitions/node.yaml
+++ b/bluepysnap/schemas/definitions/node.yaml
@@ -1,3 +1,4 @@
+$schema: https://json-schema.org/draft/2020-12/schema
 title: Node file definitions
 description: schema definitions that apply to all node files
 $node_file_defs:
@@ -17,7 +18,7 @@ $node_file_defs:
               - node_type_id
             properties:
               node_type_id:
-                $ref: "#/$typedefs/int64"
+                $ref: "#/$typedefs/signed_integer"
               "0":
                 type: object
                 properties:
@@ -86,13 +87,13 @@ $node_file_defs:
                   region:
                     $ref: "#/$typedefs/utf8"
                   section_id:
-                    $ref: "#/$typedefs/uint32"
+                    $ref: "#/$typedefs/unsigned_integer"
                   segment_id:
-                    $ref: "#/$typedefs/uint32"
+                    $ref: "#/$typedefs/unsigned_integer"
                   synapse_class:
                     $ref: "#/$typedefs/utf8"
                   type:
-                    $ref: "#/$typedefs/int32"
+                    $ref: "#/$typedefs/signed_integer"
 
                   "@library":
                     type: object
@@ -119,6 +120,6 @@ $node_file_defs:
                   end_diameter:
                     $ref: "#/$typedefs/float32"
                   start_node:
-                    $ref: "#/$typedefs/uint64"
+                    $ref: "#/$typedefs/unsigned_integer"
                   end_node:
-                    $ref: "#/$typedefs/uint64"
+                    $ref: "#/$typedefs/unsigned_integer"

--- a/bluepysnap/schemas/schemas.py
+++ b/bluepysnap/schemas/schemas.py
@@ -248,11 +248,13 @@ def _resolve_types(registry, types):
     def _resolve_type(type_):
         if type_ not in cache:
             resolved = registry.resolver().lookup(type_)
-            type_ = resolved.contents["properties"]["datatype"]["const"]
-            if hasattr(np, type_):
-                cache[type_] = getattr(np, type_)
-            elif type_ == "utf-8":
-                cache[type_] = str
+            if const := resolved.contents["properties"]["datatype"].get("const"):
+                if hasattr(np, const):
+                    cache[type_] = getattr(np, const)
+                elif const == "utf-8":
+                    cache[type_] = str
+            elif enum := resolved.contents["properties"]["datatype"].get("enum"):
+                cache[type_] = [_resolve_type(f"#/$typedefs/{v}") for v in enum]
 
         return cache[type_]
 

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -457,22 +457,31 @@ def test_wrong_datatype(field):
         edges_file = circuit_copy_path / "edges_single_pop.h5"
         with h5py.File(edges_file, "r+") as h5f:
             del h5f[field]
-            h5f.create_dataset(field, data=[0], dtype="i2")
+            h5f.create_dataset(field, data=[0], dtype="u2")
         errors = test_module.validate_edges_schema(
             str(edges_file), "chemical", virtual=False, ignore_datatype_errors=False
         )
         assert len(errors) == 1
         assert errors[0].level == BluepySnapValidationError.WARNING
-        assert f"incorrect datatype 'int16' for '{field}'" in errors[0].message
+        assert f"incorrect datatype 'uint16' for '{field}'" in errors[0].message
 
 
 def test_nodes_schema_types():
-    property_types, _ = test_module.nodes_schema_types("biophysical")
+    property_types, dynamics_params = test_module.nodes_schema_types("biophysical")
     assert "x" in property_types
     assert property_types["x"] == np.float32
+
+    assert "section_id" in property_types
+    assert property_types["section_id"] == [np.uint8, np.uint16, np.uint32, np.uint64]
+
+    assert "AIS_scaler" in dynamics_params
+    assert dynamics_params["AIS_scaler"] == np.float32
 
 
 def test_edges_schema_types():
     edge_property_types = test_module.edges_schema_types("chemical", virtual=True)
     assert "afferent_center_x" in edge_property_types
     assert edge_property_types["afferent_center_x"] == np.float32
+
+    assert "endfoot_id" in edge_property_types
+    assert edge_property_types["endfoot_id"] == [np.uint8, np.uint16, np.uint32, np.uint64]


### PR DESCRIPTION
* only the `signed`-ness has to be specified correctly
* per updated specs: https://github.com/openbraininstitute/sonata-extension/pull/30