### PR TITLE
Make `model_template` optional for virtual node populations

### DIFF
--- a/bluepysnap/schemas/node/virtual.yaml
+++ b/bluepysnap/schemas/node/virtual.yaml
@@ -9,5 +9,4 @@ properties:
         properties:
           "0":
             required:
-              - model_template
               - model_type

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -404,6 +404,18 @@ def test_virtual_node_population_ok():
         assert len(errors) == 0
 
 
+def test_virtual_node_population_without_model_template_ok():
+    """model_template is optional for virtual populations and may be absent."""
+    with copy_test_data() as (circuit_copy_path, _):
+        nodes_file = circuit_copy_path / "nodes_single_pop.h5"
+        with h5py.File(nodes_file, "r+") as h5f:
+            del h5f["nodes/default/0/model_template"]
+        errors = test_module.validate_nodes_schema(
+            str(nodes_file), "virtual", ignore_datatype_errors=False
+        )
+        assert len(errors) == 0
+
+
 def test_virtual_node_population_error():
     with copy_test_data() as (circuit_copy_path, _):
         nodes_file = circuit_copy_path / "nodes_single_pop.h5"


### PR DESCRIPTION
## Problem

The schema for virtual node populations requires `model_template`, but virtual nodes have no applicable electrophysiological model. This forces writers to include a column filled with empty strings, which clutters the table view of neuron properties.

The SONATA spec (sonata-extension) has been updated to make `model_template` optional for virtual populations. The brainbuilder extraction code has been updated to stop writing the column and strip it during extraction.

This PR aligns the bluepysnap validation schema with the updated spec.

## Changes

- `bluepysnap/schemas/node/virtual.yaml`: removed `model_template` from the `required` list.
- `tests/test_schemas.py`: added `test_virtual_node_population_without_model_template_ok` to verify that a virtual population without `model_template` passes schema validation.

## Backward compatibility

Circuits that still have `model_template` on virtual populations (with empty strings) remain valid — the field is still allowed, just no longer required.

## Related

- sonata-extension PR: makes `model_template` optional in the spec.
- brainbuilder PR: stops writing the column and strips it during extraction.
